### PR TITLE
Add a closeModal() method to explicitly close VS toggling the modal

### DIFF
--- a/dist/vue-carousel.js
+++ b/dist/vue-carousel.js
@@ -838,6 +838,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	        return bodyClass.add("modal-active");
 	      }
 	    },
+	    closeModal: function closeModal() {
+	      var bodyClass = document.body.classList;
+	      if (bodyClass.contains('modal-active')) {
+	        if (this.forceModal) {
+	          this.currentPage = 0;
+	        }
+	        this.modalEnabled = false;
+	        return bodyClass.remove("modal-active");
+	      }
+	    },
 	    modalToggle: function modalToggle() {
 	      var bodyClass = document.body.classList;
 	      if (bodyClass.contains("modal-active")) {
@@ -854,7 +864,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	      var vm = this;
 	      window.addEventListener("keyup", function (e) {
 	        if (e.key === "Escape") {
-	          return vm.modalToggle();
+	          return vm.closeModal();
 	        }
 	        return false;
 	      });

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -457,6 +457,16 @@
           return bodyClass.add("modal-active")
         }
       },
+      closeModal() {
+        const bodyClass = document.body.classList
+        if (bodyClass.contains('modal-active')) {
+          if (this.forceModal) {
+            this.currentPage = 0
+          }
+          this.modalEnabled = false
+          return bodyClass.remove("modal-active")
+        }
+      },
       modalToggle() {
         const bodyClass = document.body.classList
         if (bodyClass.contains("modal-active")) {
@@ -473,7 +483,7 @@
         const vm = this
         window.addEventListener("keyup", (e) => {
           if (e.key === "Escape") {
-            return vm.modalToggle()
+            return vm.closeModal()
           }
           return false
         })


### PR DESCRIPTION
This PR explicitly `closes` a modal, VS the `toggle` method which was previously used exclusively. 