### PR TITLE
Modal Full Screen Updates

### DIFF
--- a/dist/vue-carousel.js
+++ b/dist/vue-carousel.js
@@ -706,10 +706,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	    },
 	    currentOffset: function currentOffset() {
 	      var page = this.currentPage;
-	      var width = this.slideWidth;
 	      var dragged = this.dragOffset;
+	      var width = this.slideWidth;
+
+	      if (this.modalEnabled) {
+	        width = this.browserWidth;
+	      }
 
 	      var offset = this.scrollPerPage ? page * width * this.currentPerPage : page * width;
+
+	      console.log(offset);
 
 	      return (offset + dragged) * -1;
 	    },
@@ -719,6 +725,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    pageCount: function pageCount() {
 	      var slideCount = this.slideCount;
 	      var perPage = this.currentPerPage;
+
+	      if (this.modalEnabled) {
+	        return slideCount;
+	      }
 
 	      if (this.scrollPerPage) {
 	        var pages = Math.ceil(slideCount / perPage);
@@ -730,6 +740,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	    slideWidth: function slideWidth() {
 	      var width = this.carouselWidth;
 	      var perPage = this.currentPerPage;
+
+	      if (this.modalEnabled) {
+	        return this.browserWidth;
+	      }
 
 	      return width / perPage;
 	    },
@@ -851,14 +865,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	    modalToggle: function modalToggle() {
 	      var bodyClass = document.body.classList;
 	      if (bodyClass.contains("modal-active")) {
-	        if (this.forceModal) {
-	          this.currentPage = 0;
-	        }
-	        this.modalEnabled = false;
-	        return bodyClass.remove("modal-active");
+	        return this.closeModal();
 	      }
-	      this.modalEnabled = true;
-	      return bodyClass.add("modal-active");
+	      return this.openModal();
 	    },
 	    addHotKeys: function addHotKeys() {
 	      var vm = this;

--- a/src/Carousel.vue
+++ b/src/Carousel.vue
@@ -254,13 +254,17 @@
        */
       currentOffset() {
         const page = this.currentPage
-        const width = this.slideWidth
         const dragged = this.dragOffset
+        let width = this.slideWidth
+        
+        if(this.modalEnabled) {
+          width = this.browserWidth
+        }
 
         // The offset distance depends on whether the scrollPerPage option is active.
         // If this option is active, the offset will be determined per page rather than per item.
         const offset = (this.scrollPerPage) ? (page * width * this.currentPerPage) : (page * width)
-
+        
         return (offset + dragged) * -1
       },
       isHidden() {
@@ -273,6 +277,10 @@
       pageCount() {
         const slideCount = this.slideCount
         const perPage = this.currentPerPage
+        
+        if (this.modalEnabled) {
+          return slideCount
+        }
 
         if (this.scrollPerPage) {
           const pages = Math.ceil(slideCount / perPage)
@@ -295,6 +303,10 @@
       slideWidth() {
         const width = this.carouselWidth
         const perPage = this.currentPerPage
+        
+        if(this.modalEnabled) {
+          return this.browserWidth
+        }
 
         return width / perPage
       },
@@ -470,14 +482,9 @@
       modalToggle() {
         const bodyClass = document.body.classList
         if (bodyClass.contains("modal-active")) {
-          if (this.forceModal) {
-            this.currentPage = 0
-          }
-          this.modalEnabled = false
-          return bodyClass.remove("modal-active")
+          return this.closeModal()
         }
-        this.modalEnabled = true
-        return bodyClass.add("modal-active")
+        return this.openModal()
       },
       addHotKeys() {
         const vm = this


### PR DESCRIPTION
This PR helps all those mini carousels out there grow up like their big brothers. When you open the modal, we want the image full screen (at least within its container). Also, refactor the open/close methods so the `modalToggle()` function is always using those methods.